### PR TITLE
Use realpath so --pwd argument works

### DIFF
--- a/ws_workflow/_scripts/gui-nvidia-shell.bash
+++ b/ws_workflow/_scripts/gui-nvidia-shell.bash
@@ -2,7 +2,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # Change directory because it doesn't exist in container, and so won't be bound
 cd $DIR
-WS_DIR=$DIR/..
+WS_DIR=$(realpath $DIR/..)
 
 . __find_sandbox.bash
 

--- a/ws_workflow/_scripts/rootshell.bash
+++ b/ws_workflow/_scripts/rootshell.bash
@@ -2,7 +2,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # Change directory because it doesn't exist in container, and so won't be bound
 cd $DIR
-WS_DIR=$DIR/..
+WS_DIR=$(realpath $DIR/..)
 
 . __find_sandbox.bash
 

--- a/ws_workflow/_scripts/shell.bash
+++ b/ws_workflow/_scripts/shell.bash
@@ -2,7 +2,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # Change directory because it doesn't exist in container, and so won't be bound
 cd $DIR
-WS_DIR=$DIR/..
+WS_DIR=$(realpath $DIR/..)
 
 . __find_sandbox.bash
 


### PR DESCRIPTION
Makes it so the directory one starts in in the container is at the root of the workspace. The problem was `--pwd` silently fails when the path contains `..`