### PR TITLE
Create COLCON/CATKIN ignore file at filesystem root

### DIFF
--- a/almalinux8-ros/Apptainer
+++ b/almalinux8-ros/Apptainer
@@ -13,6 +13,9 @@ From: almalinux:8
 
 
 %post
+  # Block searching the entire filesystem for packages when using a sandbox
+  touch /COLCON_IGNORE /CATKIN_IGNORE
+
   # Enable EPEL and PowerTools repositories
   dnf install epel-release epel-release 'dnf-command(config-manager)' --refresh -y
   dnf config-manager --set-enabled powertools

--- a/bionic-ros/Apptainer
+++ b/bionic-ros/Apptainer
@@ -13,6 +13,9 @@ From: ubuntu:18.04
 
 
 %post
+  # Block searching the entire filesystem for packages when using a sandbox
+  touch /COLCON_IGNORE /CATKIN_IGNORE
+
   apt-get update
   apt-get install -y \
     locales \

--- a/bullseye-ros/Apptainer
+++ b/bullseye-ros/Apptainer
@@ -13,6 +13,9 @@ From: debian:10
 
 
 %post
+  # Block searching the entire filesystem for packages when using a sandbox
+  touch /COLCON_IGNORE /CATKIN_IGNORE
+
   export DEBIAN_FRONTEND=noninteractive
 
   apt-get update

--- a/buster-ros/Apptainer
+++ b/buster-ros/Apptainer
@@ -13,6 +13,9 @@ From: debian:10
 
 
 %post
+  # Block searching the entire filesystem for packages when using a sandbox
+  touch /COLCON_IGNORE /CATKIN_IGNORE
+
   export DEBIAN_FRONTEND=noninteractive
 
   apt-get update

--- a/focal-ros-galactic-desktop/Apptainer
+++ b/focal-ros-galactic-desktop/Apptainer
@@ -11,6 +11,9 @@ From: ubuntu:20.04
 
 
 %post
+  # Block searching the entire filesystem for packages when using a sandbox
+  touch /COLCON_IGNORE /CATKIN_IGNORE
+
   export DEBIAN_FRONTEND=noninteractive
 
   apt-get update

--- a/focal-ros/Apptainer
+++ b/focal-ros/Apptainer
@@ -9,6 +9,9 @@ From: ubuntu:20.04
 
 
 %post
+  # Block searching the entire filesystem for packages when using a sandbox
+  touch /COLCON_IGNORE /CATKIN_IGNORE
+
   export DEBIAN_FRONTEND=noninteractive
 
   apt-get update

--- a/jammy-ros-humble-desktop/Apptainer
+++ b/jammy-ros-humble-desktop/Apptainer
@@ -11,6 +11,9 @@ From: ubuntu:22.04
 
 
 %post
+  # Block searching the entire filesystem for packages when using a sandbox
+  touch /COLCON_IGNORE /CATKIN_IGNORE
+
   export DEBIAN_FRONTEND=noninteractive
 
   apt-get update

--- a/jammy-ros/Apptainer
+++ b/jammy-ros/Apptainer
@@ -10,6 +10,9 @@ From: ubuntu:22.04
 
 
 %post
+  # Block searching the entire filesystem for packages when using a sandbox
+  touch /COLCON_IGNORE /CATKIN_IGNORE
+
   export DEBIAN_FRONTEND=noninteractive
 
   apt-get update


### PR DESCRIPTION
Fixes #5

`COLCON_IGNORE` should be enough for most platforms since modern versions of `catkin-pkg` watch for those files too, but I added `CATKIN_IGNORE` anyways in case someone wanted to use a very old version of `catkin-pkg`.